### PR TITLE
SM-438 | feat: add `isPrivate` property for dOTC offers

### DIFF
--- a/schema.dotc.graphql
+++ b/schema.dotc.graphql
@@ -160,7 +160,8 @@ type Offer @entity {
   amountOut: BigDecimal!
   price: BigDecimal!
   offerType: BigInt!
-  specialAddress: Bytes!
+  isPrivate: Boolean!
+  specialAddress: Bytes
   isCompleted: Boolean!
   orders: [Order!]! @derivedFrom(field: "offers")
   cancelled: Boolean!
@@ -187,7 +188,8 @@ type NftOffer @entity {
   nftIds: [BigInt!]!
   nftAmounts: [BigInt!]!
   expiresAt: BigInt!
-  specialAddress: Bytes!
+  isPrivate: Boolean!
+  specialAddress: Bytes
   isCompleted: Boolean!
   orders: [NftOrder!]! @derivedFrom(field: "offers")
   createdAt: BigInt!

--- a/src/mappings/dOTCManager.ts
+++ b/src/mappings/dOTCManager.ts
@@ -1,4 +1,5 @@
-import { BigInt } from '@graphprotocol/graph-ts'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { ZERO_ADDRESS } from '../constants/common'
 import {
   CanceledOffer,
   CompletedOffer,
@@ -38,7 +39,14 @@ export function handleNewOffer(event: CreatedOffer): void {
   }
 
   offer.offerType = BigInt.fromI32(event.params.offerType)
-  offer.specialAddress = event.params.specialAddress
+
+  let specialAddress = event.params.specialAddress
+  let isPrivate = Address.fromString(ZERO_ADDRESS).notEqual(specialAddress)
+  offer.isPrivate = isPrivate
+  if (isPrivate) {
+    offer.specialAddress = specialAddress
+  }
+
   offer.isCompleted = event.params.isComplete
   offer.availableAmount = bigIntToDecimal(
     event.params.amountIn,
@@ -116,7 +124,13 @@ export function handleNewNftOffer(event: CreatedNftOffer): void {
   offer.tokenOut = tokenOut.id
   offer.offerPrice = bigIntToDecimal(event.params.offerPrice, tokenOut.decimals)
 
-  offer.specialAddress = event.params.specialAddress
+  let specialAddress = event.params.specialAddress
+  let isPrivate = Address.fromString(ZERO_ADDRESS).notEqual(specialAddress)
+  offer.isPrivate = isPrivate
+  if (isPrivate) {
+    offer.specialAddress = specialAddress
+  }
+
   offer.isCompleted = false
   offer.cancelled = false
   offer.createdAt = event.block.timestamp


### PR DESCRIPTION
In current PR I changed `specialAddress` field of the offer to optional and added `isPrivate` field as required to improve the available filters for requests.
It is deployed to my subgraph: [https://thegraph.com/hosted-service/subgraph/elviskrop/abstract-graph](https://thegraph.com/hosted-service/subgraph/elviskrop/abstract-graph).
![image](https://user-images.githubusercontent.com/47831692/158169626-ebebe430-fb9a-4405-9d12-4169ac1c4bc7.png)
