### PR TITLE
SM-0 | fix: skip erc20 and erc1155 registration if the desired contract is missing symbol or name or decimals

### DIFF
--- a/src/mappings/dOTCListedToken.ts
+++ b/src/mappings/dOTCListedToken.ts
@@ -10,7 +10,7 @@ export function registerERC20Token(event: RegisterERC20Token): void {
   let tokenId = event.params.token.toHexString()
   let erc20Token = ERC20Token.loadOrCreate(tokenId)
 
-  if (erc20Token.paused) {
+  if (!!erc20Token && erc20Token.paused) {
     erc20Token.paused = false
     erc20Token.save()
   }
@@ -20,7 +20,7 @@ export function registerERC1155Token(event: RegisterERC1155Token): void {
   let erc1155TokenId = event.params.token.toHexString()
   let erc1155Token = ERC1155Token.loadOrCreate(erc1155TokenId)
 
-  if (erc1155Token.paused) {
+  if (!!erc1155Token && erc1155Token.paused) {
     erc1155Token.paused = false
     erc1155Token.save()
   }


### PR DESCRIPTION
Current changes are deployed [here](https://thegraph.com/hosted-service/subgraph/elviskrop/abstract-graph)
If someone will try to register contract that has no name or symbol or decimals it will be skipped and there will a warning message on the subgraph, like that:
![image](https://user-images.githubusercontent.com/47831692/163410397-1e31cfb6-57af-44c0-9072-9d78853d9595.png)
