### PR TITLE
SM-951 | feat: update `pool.active` if there is some liquidity in the pool and we change the `xSPT.paused` field

### DIFF
--- a/src/mappings/xtoken.ts
+++ b/src/mappings/xtoken.ts
@@ -31,6 +31,13 @@ function changeXTokenState(xTokenAddress: Address, paused: boolean): void {
 
   token.paused = paused
   token.save()
+
+  let pool = Pool.load(token.id)
+
+  if (pool !== null && pool.totalShares.notEqual(ZERO_BD)) {
+    pool.active = !paused
+    pool.save()
+  }
 }
 
 export function handleTransfer(event: Transfer): void {


### PR DESCRIPTION
The pool with active field equal to false will be filtered in UI by default 