### PR TITLE
SM-966 | fix(workflows): remove duplicated inputs context

### DIFF
--- a/.github/workflows/graph.mainnet.yml
+++ b/.github/workflows/graph.mainnet.yml
@@ -59,5 +59,5 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
-          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}${{ github.event.inputs.SUBGRAPH_NAME }}
+          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}
         run: yarn deploy

--- a/.github/workflows/graph.mumbai.yml
+++ b/.github/workflows/graph.mumbai.yml
@@ -59,5 +59,5 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
-          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}${{ github.event.inputs.SUBGRAPH_NAME }}
+          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}
         run: yarn deploy

--- a/.github/workflows/graph.polygon.yml
+++ b/.github/workflows/graph.polygon.yml
@@ -59,5 +59,5 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
-          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}${{ github.event.inputs.SUBGRAPH_NAME }}
+          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}
         run: yarn deploy

--- a/.github/workflows/graph.rinkeby.yml
+++ b/.github/workflows/graph.rinkeby.yml
@@ -59,5 +59,5 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
-          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}${{ github.event.inputs.SUBGRAPH_NAME }}
+          SUBGRAPH_NAME: ${{ inputs.SUBGRAPH_NAME }}
         run: yarn deploy


### PR DESCRIPTION
There are several workflows that are reusable and available for manual trigger. Previously, `inputs` context was available only for reusable workflow and `github.event.inputs` context was available for manual triggered workflow.

Looks like last week GitHub merged those two contexts for manual triggered workflows. Unfortunately, I cannot find any change log to provide the proof of my guess.